### PR TITLE
when_committed! will run immediately if not in a transaction

### DIFF
--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -11,6 +11,14 @@ module WhenCommitted
       when_committed_callbacks << block
     end
 
+    def when_committed!(&block)
+      if self.connection.open_transactions > 0
+        when_committed(&block)
+      else
+        block.call
+      end
+    end
+
     private
 
     def when_committed_callbacks


### PR DESCRIPTION
If you call `when_committed` outside of a transaction,
and never save the model, the block will never run.
This may be exactly what you want, since the block
might depend on changes to the model.

`when_committed!` is useful in scenarios where you
don't know if the code will be called as part of a
transaction or other model change. If it happens
as part of transaction, wait until it is committed.
