### PR TITLE
Support for rails 4

### DIFF
--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -12,7 +12,7 @@ module WhenCommitted
     end
 
     def when_committed!(&block)
-      if self.connection.open_transactions > 0
+      if self.class.connection.open_transactions > 0
         when_committed(&block)
       else
         block.call

--- a/spec/when_committed_spec.rb
+++ b/spec/when_committed_spec.rb
@@ -3,7 +3,8 @@ require 'when_committed'
 
 describe "WhenCommitted" do
   before(:all) do
-    ActiveRecord::Base.establish_connection :adapter => :nulldb
+    ActiveRecord::Base.establish_connection :adapter => :sqlite3,
+                                            :database => ":memory:"
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define do
       create_table(:widgets) do |t|

--- a/spec/when_committed_spec.rb
+++ b/spec/when_committed_spec.rb
@@ -11,11 +11,13 @@ describe "WhenCommitted" do
         t.string  :name
         t.integer :size
       end
+
+      create_table(:samples)
     end
   end
 
   it "provides a #when_committed method" do
-    sample_class = Class.new(ActiveRecord::Base)
+    sample_class = Sample
     model = sample_class.new
     model.should_not respond_to(:when_committed)
     sample_class.send :include, WhenCommitted::ActiveRecord
@@ -104,6 +106,9 @@ describe "WhenCommitted" do
       Backgrounder.should have(1).job
     end
   end
+end
+
+class Sample < ActiveRecord::Base
 end
 
 class Widget < ActiveRecord::Base

--- a/when_committed.gemspec
+++ b/when_committed.gemspec
@@ -20,6 +20,6 @@ dynamically define a block of code that should run when the transaction is commi
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_dependency "activerecord", ">=3.1"
-  gem.add_development_dependency "activerecord-nulldb-adapter"
+  gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "rspec"
 end

--- a/when_committed.gemspec
+++ b/when_committed.gemspec
@@ -21,5 +21,5 @@ dynamically define a block of code that should run when the transaction is commi
   gem.require_paths = ["lib"]
   gem.add_dependency "activerecord", ">=3.1"
   gem.add_development_dependency "sqlite3"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", "2.14.1"
 end


### PR DESCRIPTION
This gem didn't work properly with rails 4 because of the use of `ActiveRecord::Base#connection`, which was removed in favor of accessing the connection from the class.

The nulldb adapter for tests doesn't support rails 4.2, removed it in favor of an in-memory sqlite connection.