### PR TITLE
Major rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,8 @@ could try moving that code to an `after_commit` callback, but then you do not
 have access to the `#changes` to your model (they have already been applied), so
 it may be difficult to make decisions on whether to enqueue the job or not.
 
-## Installation
-
-Add this line to your application's Gemfile:
-
-    gem 'when_committed'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install when_committed
+It can also be useful for running some code in the same process, but outside of
+the current transaction.
 
 ## Usage
 
@@ -39,12 +28,44 @@ is committed:
     def update_score(new_score)
       self.score = new_score
       when_committed { Resque.enqueue(RecalculateAggregateScores, self.id) }
+      self.score_changed = true
     end
+
+By default, `when_committed` will raise an exception if it is called outside
+of an ActiveRecord transaction, since the block would never be run.
+If you need it to also be able to run outside of a transaction (e.g. if you
+have multiple callsites - some in a transaction, some not), specify the
+`run_now_if_no_transaction: true` argument.
+
+
+    def update_score(new_score)
+      self.score = new_score
+      when_committed(run_now_if_no_transaction: true) {
+        Resque.enqueue(RecalculateAggregateScores, self.id)
+      }
+      self.score_changed = true
+    end
+
+Be aware that when using this argument, the order of execution changes
+depending on if a transaction is present or not. When a transaction is present,
+`score` will be set, then `score_changed` is set, then eventually the Resque
+call is made when the transaction commits. When a transaction is not present,
+`score` will be set, then the Resque call is made, then `score_changed` is set.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'when_committed', github: 'ShippingEasy/when_committed'
+
+And then execute:
+
+    $ bundle
 
 ## Contributing
 
-1. [Fork it](https://github.com/PeopleAdmin/when_committed/fork_select)
+1. [Fork it](https://github.com/ShippingEasy/when_committed/fork_select)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. [Create new Pull Request](https://github.com/PeopleAdmin/when_committed/pull/new/master)
+5. [Create new Pull Request](https://github.com/ShippingEasy/when_committed/pull/new/master)

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -24,8 +24,15 @@ module WhenCommitted
       @callback = callback
     end
 
-    def committed!
-      @callback.call
+    def committed!(should_run_callbacks=true)
+      # should_run_callbacks will only be false if we're in the process of
+      # raising an exception (caused by another callback) and AR is giving us
+      # a chance to clean up any internal state.
+      # We should be consistent with ActiveRecord and *not* run the remaining
+      # callbacks>
+      if should_run_callbacks
+        @callback.call
+      end
     end
 
     def rolledback!(*)

--- a/spec/when_committed_spec.rb
+++ b/spec/when_committed_spec.rb
@@ -18,6 +18,11 @@ describe "WhenCommitted" do
     end
   end
 
+  before(:each) do
+    # Make sure exceptions aren't swallowed in tests
+    ActiveRecord::Base.raise_in_transactional_callbacks = true
+  end
+
   it "provides a #when_committed method" do
     sample_class = Sample
     model = sample_class.new
@@ -176,6 +181,46 @@ describe "WhenCommitted" do
         rescue
         end
         Backgrounder.jobs.should == []
+      end
+    end
+
+    context "when a previous callback raised an exception" do
+      it "still runs the block if raise_in_transactional_callbacks is false" do
+        ActiveRecord::Base.raise_in_transactional_callbacks = false
+
+        w1 = Widget.new
+        w2 = Widget.new
+        w3 = Widget.new
+        w4 = Widget.new
+
+        Widget.transaction do
+          w1.when_committed { Backgrounder.enqueue :first }
+          w2.when_committed { raise Catastrophe }
+          w3.when_committed { Backgrounder.enqueue :third }
+          w4.when_committed { Backgrounder.enqueue :fourth }
+        end
+
+        Backgrounder.jobs.should == [:first, :third, :fourth]
+      end
+
+      it "does not run the block if raise_in_transactional_callbacks is true" do
+        ActiveRecord::Base.raise_in_transactional_callbacks = true
+
+        w1 = Widget.new
+        w2 = Widget.new
+        w3 = Widget.new
+        w4 = Widget.new
+
+        expect {
+          Widget.transaction do
+            w1.when_committed { Backgrounder.enqueue :first }
+            w2.when_committed { raise Catastrophe }
+            w3.when_committed { Backgrounder.enqueue :third }
+            w4.when_committed { Backgrounder.enqueue :fourth }
+          end
+        }.to raise_error(Catastrophe)
+
+        Backgrounder.jobs.should == [:first]
       end
     end
   end


### PR DESCRIPTION
This addresses the two biggest issues we've run into with `when_committed` over the last couple years. Before this change, there were some subtle bugs that made it very easy to lose confidence in `when_committed` as a valid solution.

- callbacks are no longer tied to specific instances. They will be called when the open transaction is
committed, even if the instance they were defined on is not altered/saved.
- `when_committed!` has been replaced by the more explicit `when_committed(run_now_if_no_transaction: true)`
- `when_committed` (without the above argument) will now raise if called without an open transaction. This eliminates the easy mistake of defining a block that will never be called, since there is no transaction to commit.

Best viewed using the side-by-side "Split" diff view.
