### PR TITLE
Jordank/when committed rails 5

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0
+
+* Add a dependency on active_record >= 5.1
+* Add no_op `before_committed!` and `add_to_transaction` methods to `WhenCommitted::CallbackRecord` for Rails 5.1 compatibility
+  The `ActiveRecord::ConnectionAdapters::Transaction` API changed to now expect "record-like" objects to respond to these methodsß
+* Update `committed!` to accept keyword arguments for Rails 5.1 compatibility

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -24,7 +24,7 @@ module WhenCommitted
       @callback = callback
     end
 
-    def committed!(should_run_callbacks=true)
+    def committed!(should_run_callbacks: true, **)
       # should_run_callbacks will only be false if we're in the process of
       # raising an exception (caused by another callback) and AR is giving us
       # a chance to clean up any internal state.
@@ -37,6 +37,13 @@ module WhenCommitted
 
     def rolledback!(*)
     end
+
+    def before_committed!(*)
+    end
+
+    def add_to_transaction(*)
+    end
+
   end
 
   class RequiresTransactionError < StandardError

--- a/lib/when_committed/version.rb
+++ b/lib/when_committed/version.rb
@@ -1,3 +1,3 @@
 module WhenCommitted
-  VERSION = "0.9.0"
+  VERSION = "1.0.0"
 end

--- a/when_committed.gemspec
+++ b/when_committed.gemspec
@@ -19,7 +19,7 @@ dynamically define a block of code that should run when the transaction is commi
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency "activerecord", ">=3.1"
+  gem.add_dependency "activerecord", ">=5.1"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "rspec", "2.14.1"
 end


### PR DESCRIPTION
### Why?
For rails 5.1 compatibility, we needed to update the `committed!` method to accept keyword arguments and add new methods that the `ActiveRecord::ConnectionAdapters::Transaction` API expected "record-like" objects to respond to.

### What?
Added the necessary methods and a changelog to document the changes made in the version upgrade