### PR TITLE
Add trigger_transactional_callbacks? method for Rails 6.0 compatibility

### DIFF
--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -49,6 +49,12 @@ module WhenCommitted
       @connection.add_transaction_record(self)
     end
 
+    def trigger_transactional_callbacks?
+      # This method is meant to be a check whether the record has been persisted
+      # or destroyed, and if those callbacks need to be run. That doesn't apply
+      # here, so always return true.
+      true
+    end
   end
 
   class RequiresTransactionError < StandardError


### PR DESCRIPTION
## Why?

This gem triggers a `NoMethodError` in Rails 6.0, when ActiveRecord tries to determine if a record should trigger callbacks. To fix it, `CallbackRecord` needs to respond to `trigger_transactional_callbacks?`. The change should be safe for Rails 5.2 as well, since we're just adding a method that doesn't exist/get used in Rails 5.

## What?

The `trigger_transactional_callbacks?` method is meant to return `true` if the record has been persisted or destroyed, and callbacks should be run. In the case of a `CallbackRecord` there's no notion of persistence, so this should always be true when the record is "committed". The value during a rollback doesn't matter since it's a no-op for a `CallbackRecord`.

New method is originally defined [here](https://github.com/rails/rails/blob/v6.0.2.1/activerecord/lib/active_record/transactions.rb#L381-L384)
And used in the `commit_records` and `rollback_records` methods [here](https://github.com/rails/rails/blob/v6.0.2.1/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L100-L135)

The previous version of those methods from 5.2.3 is [here](https://github.com/rails/rails/blob/v5.2.3/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L109-L136).