### PR TITLE
Bump version to 1.0.2 with Rails 6.0 compatibility

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,8 +1,17 @@
 # Changelog
 
+## 1.0.2
+
+* Add trigger_transactional_callbacks? method for Rails 6.0 compatibility
+
+## 1.0.1
+
+* Restore support for callbacks defined within nested transactions
+* Drop support for removed raise_in_transactional_callbacks options
+
 ## 1.0.0
 
 * Add a dependency on active_record >= 5.1
 * Add no_op `before_committed!` and `add_to_transaction` methods to `WhenCommitted::CallbackRecord` for Rails 5.1 compatibility
-  The `ActiveRecord::ConnectionAdapters::Transaction` API changed to now expect "record-like" objects to respond to these methodsß
+  The `ActiveRecord::ConnectionAdapters::Transaction` API changed to now expect "record-like" objects to respond to these methods
 * Update `committed!` to accept keyword arguments for Rails 5.1 compatibility

--- a/lib/when_committed/version.rb
+++ b/lib/when_committed/version.rb
@@ -1,3 +1,3 @@
 module WhenCommitted
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Updates gem version and changelog with latest changes. Probably should have included this on the last branch that was merged.

Once this is merged, it should be good to merge to `deploy`, and begin using with Rails 6.0