### PR TITLE
v1.0.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,8 +1,17 @@
 # Changelog
 
+## 1.0.2
+
+* Add trigger_transactional_callbacks? method for Rails 6.0 compatibility
+
+## 1.0.1
+
+* Restore support for callbacks defined within nested transactions
+* Drop support for removed raise_in_transactional_callbacks options
+
 ## 1.0.0
 
 * Add a dependency on active_record >= 5.1
 * Add no_op `before_committed!` and `add_to_transaction` methods to `WhenCommitted::CallbackRecord` for Rails 5.1 compatibility
-  The `ActiveRecord::ConnectionAdapters::Transaction` API changed to now expect "record-like" objects to respond to these methodsß
+  The `ActiveRecord::ConnectionAdapters::Transaction` API changed to now expect "record-like" objects to respond to these methods
 * Update `committed!` to accept keyword arguments for Rails 5.1 compatibility

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -49,6 +49,12 @@ module WhenCommitted
       @connection.add_transaction_record(self)
     end
 
+    def trigger_transactional_callbacks?
+      # This method is meant to be a check whether the record has been persisted
+      # or destroyed, and if those callbacks need to be run. That doesn't apply
+      # here, so always return true.
+      true
+    end
   end
 
   class RequiresTransactionError < StandardError

--- a/lib/when_committed/version.rb
+++ b/lib/when_committed/version.rb
@@ -1,3 +1,3 @@
 module WhenCommitted
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Updates to v1.0.2 for Rails 6 compatibility.

Only adds a method new to Rails 6 to maintain compatibility with `ActiveRecord::Transactions`. No existing behavior has changed, so fully backwards compatible with Rails 5.2, and safe to use before upgrading to Rails 6.